### PR TITLE
Deleting Documents

### DIFF
--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/Nunaliit.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/Nunaliit.java
@@ -21,4 +21,7 @@ public class Nunaliit {
     public static final String EXTRA_SYNC_REMOTE_TOTAL = "ca.carleton.gcrc.EXTRA_SYNC_REMOTE_TOTAL";
 
     public static final String EXTRA_SYNC_PROGRESS_STATE = "ca.carleton.gcrc.EXTRA_SYNC_PROGRESS_STATE";
+
+    public static final String EXTRA_SYNC_DOCUMENT_LOCAL_DELETE = "ca.carleton.gcrc.EXTRA_SYNC_DOCUMENT_LOCAL_DELETE";
+    public static final String EXTRA_SYNC_DOCUMENT_REQUEST_DELETE = "ca.carleton.gcrc.EXTRA_SYNC_DOCUMENT_REQUEST_DELETE";
 }

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/activities/EmbeddedCordovaActivity.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/activities/EmbeddedCordovaActivity.java
@@ -714,8 +714,8 @@ public class EmbeddedCordovaActivity extends CordovaActivity {
 
                 clientResult.setText(String.format(getString(R.string.sync_client_update), clientSuccess, clientTotal));
                 remoteResult.setText(String.format(getString(R.string.sync_remote_update), remoteSuccess, remoteTotal));
-                totalDeletedResult.setText(String.format("Documents Deleted: %d", documentsLocalDeleted));
-                requestedDeletedResult.setText(String.format("Document Delete Requests: %d", documentRequestedDelete));
+                totalDeletedResult.setText(String.format(getString(R.string.sync_local_delete), documentsLocalDeleted));
+                requestedDeletedResult.setText(String.format(getString(R.string.sync_remote_delete), documentRequestedDelete));
             }
         });
 

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/activities/EmbeddedCordovaActivity.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/activities/EmbeddedCordovaActivity.java
@@ -702,13 +702,20 @@ public class EmbeddedCordovaActivity extends CordovaActivity {
                 int remoteSuccess = intent.getIntExtra(Nunaliit.EXTRA_SYNC_REMOTE_SUCCESS, 0);
                 int remoteTotal = intent.getIntExtra(Nunaliit.EXTRA_SYNC_REMOTE_TOTAL, 0);
 
+                int documentsLocalDeleted = intent.getIntExtra(Nunaliit.EXTRA_SYNC_DOCUMENT_LOCAL_DELETE, 0);
+                int documentRequestedDelete = intent.getIntExtra(Nunaliit.EXTRA_SYNC_DOCUMENT_REQUEST_DELETE, 0);
+
                 Dialog innerDialog = (Dialog) dialogInterface;
 
                 TextView clientResult = innerDialog.findViewById(R.id.sync_client_update_result);
                 TextView remoteResult = innerDialog.findViewById(R.id.sync_remote_update_result);
+                TextView totalDeletedResult = innerDialog.findViewById(R.id.sync_total_documents_deleted_result);
+                TextView requestedDeletedResult = innerDialog.findViewById(R.id.sync_requested_documents_deleted_result);
 
                 clientResult.setText(String.format(getString(R.string.sync_client_update), clientSuccess, clientTotal));
                 remoteResult.setText(String.format(getString(R.string.sync_remote_update), remoteSuccess, remoteTotal));
+                totalDeletedResult.setText(String.format("Documents Deleted: %d", documentsLocalDeleted));
+                requestedDeletedResult.setText(String.format("Document Delete Requests: %d", documentRequestedDelete));
             }
         });
 

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/ConnectionManagementService.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/ConnectionManagementService.java
@@ -307,6 +307,9 @@ public class ConnectionManagementService extends IntentService {
             result.putExtra(Nunaliit.EXTRA_SYNC_REMOTE_SUCCESS, syncResult.getFilesRemoteUpdated());
             result.putExtra(Nunaliit.EXTRA_SYNC_REMOTE_TOTAL, syncResult.getFilesRemoteUpdated() + syncResult.getFilesFailedRemoteUpdated());
 
+            result.putExtra(Nunaliit.EXTRA_SYNC_DOCUMENT_LOCAL_DELETE, syncResult.getFilesDeletedLocal());
+            result.putExtra(Nunaliit.EXTRA_SYNC_DOCUMENT_REQUEST_DELETE, syncResult.getFilesDeleteRequest());
+
             LocalBroadcastManager.getInstance(this).sendBroadcast(result);
 
             ServiceSupport.createToast(

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/ConnectionSyncProcess.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/ConnectionSyncProcess.java
@@ -60,8 +60,6 @@ public class ConnectionSyncProcess {
 
     private Map<String, SubmissionStatus> submissionStatusByDocId;
 
-    private List<JSONObject> remoteDocuments;
-
     private enum SubmissionStatus {
         NotSubmitted,
         WaitingForApproval,
@@ -92,8 +90,7 @@ public class ConnectionSyncProcess {
         JSONObject submissionStatus = getSubmissionStatus();
         submissionStatusByDocId = createSubmissionStatusMap(submissionStatus);
 
-        remoteDocuments = fetchAllRemoteDocuments();
-        List<JSONObject> localDocs = documentDb.getAllDocuments();
+        List<JSONObject> remoteDocuments = fetchAllRemoteDocuments();
 
         sendSyncProgressIntent(ConnectionManagementService.PROGRESS_SYNC_UPDATING_LOCAL_DOCUMENTS);
 
@@ -200,7 +197,7 @@ public class ConnectionSyncProcess {
     }
 
     private List<JSONObject> fetchAllRemoteDocuments() throws Exception {
-        List<JSONObject> remoteDocs = getDocsFromView("skeleton-docs");
+        List<JSONObject> remoteDocs = getDocsFromView();
 
         Log.v(TAG, "Synchronization received " + remoteDocs.size() + " skeleton document(s)");
 
@@ -241,8 +238,8 @@ public class ConnectionSyncProcess {
         return subdocuments;
     }
 
-    private List<JSONObject> getDocsFromView(String view) throws Exception {
-        return getDocsFromView(view, null);
+    private List<JSONObject> getDocsFromView() throws Exception {
+        return getDocsFromView("skeleton-docs", null);
     }
 
     private List<JSONObject> getDocsFromView(String view, Collection<String> keys) throws Exception {
@@ -385,8 +382,6 @@ public class ConnectionSyncProcess {
     }
 
     private boolean sendDeleteRequestToRemote(JSONObject documentToDelete) throws Exception {
-        SubmissionStatus documentStatus = getSubmissionStatusForDocument(documentToDelete);
-
         // You cannot submit a document without a _rev.
         if (getRevisionRecord(documentToDelete).getRemoteRevision() == null) {
             return false;
@@ -557,7 +552,7 @@ public class ConnectionSyncProcess {
         }
     }
 
-    public void writeDocumentToSubmissionDatabase(JSONObject document) throws Exception {
+    private void writeDocumentToSubmissionDatabase(JSONObject document) throws Exception {
         String cookie = getNunaliitCookie();
 
         document = removeNullAttachments(document);

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/ConnectionSyncProcess.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/ConnectionSyncProcess.java
@@ -129,7 +129,9 @@ public class ConnectionSyncProcess {
             }
 
             if (getRevisionRecord(deletedDocument).getRemoteRevision() == null) {
-                Log.v(TAG, "Can't delete a document without a revision record.");
+                Log.v(TAG, "No need to keep around documents that have not been synced" +
+                        "on remote - Delete them on local (they might be re-synced later.");
+                deleteDocumentOnMobile(deletedDocument);
                 continue;
             }
 

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/ConnectionSyncResult.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/ConnectionSyncResult.java
@@ -11,6 +11,10 @@ public class ConnectionSyncResult {
     private int filesFailedClientUpdated;
     private int filesFailedRemoteUpdated;
 
+    private int filesDeletedLocal;
+    private int filesDeletedRemote;
+    private int filesDeleteRequest;
+
     public int getFilesClientUpdated() {
         return filesClientUpdated;
     }
@@ -41,5 +45,21 @@ public class ConnectionSyncResult {
 
     public void setFilesFailedRemoteUpdated(int filesFailedRemoteUpdated) {
         this.filesFailedRemoteUpdated = filesFailedRemoteUpdated;
+    }
+
+    public int getFilesDeletedLocal() {
+        return filesDeletedLocal;
+    }
+
+    public void setFilesDeletedLocal(int filesDeletedLocal) {
+        this.filesDeletedLocal = filesDeletedLocal;
+    }
+
+    public int getFilesDeleteRequest() {
+        return filesDeleteRequest;
+    }
+
+    public void setFilesDeleteRequest(int filesDeleteRequest) {
+        this.filesDeleteRequest = filesDeleteRequest;
     }
 }

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/DocumentDb.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/DocumentDb.java
@@ -71,8 +71,8 @@ public class DocumentDb extends CouchbaseDb {
                     }
                 }
 
-                Boolean deleted = Couchbase.optBoolean(document, "nunaliit_mobile_deleted");
-                if (deleted == null || !deleted) {
+                Boolean deleted = Couchbase.optBoolean(document, "nunaliit_mobile_deleted", false);
+                if (!deleted) {
                     emitter.emit(id, value);
                 }
             }

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/DocumentDb.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/connection/DocumentDb.java
@@ -71,7 +71,10 @@ public class DocumentDb extends CouchbaseDb {
                     }
                 }
 
-                emitter.emit(id, value);
+                Boolean deleted = Couchbase.optBoolean(document, "nunaliit_mobile_deleted");
+                if (deleted == null || !deleted) {
+                    emitter.emit(id, value);
+                }
             }
         };
     };

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/cordova/PluginActions.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/cordova/PluginActions.java
@@ -217,7 +217,8 @@ public class PluginActions {
         try {
             DocumentDb docDb = getDocumentDb();
 
-            CouchbaseDocInfo info = docDb.deleteDocument(doc);
+            doc.put("nunaliit_mobile_deleted", true);
+            CouchbaseDocInfo info = docDb.updateDocument(doc);
 
             JSONObject result = new JSONObject();
             result.put("id", info.getId());

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/couchbase/Couchbase.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/couchbase/Couchbase.java
@@ -50,4 +50,15 @@ public class Couchbase {
 
         return value;
     }
+
+    static public Boolean optBoolean(Map<String, Object> map, String key) {
+        Boolean value = null;
+
+        Object obj = opt(map, key);
+        if( null != obj && obj instanceof Boolean ){
+            value = (Boolean) obj;
+        }
+
+        return value;
+    }
 }

--- a/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/couchbase/Couchbase.java
+++ b/app/src/main/java/ca/carleton/gcrc/n2android_mobile1/couchbase/Couchbase.java
@@ -51,12 +51,16 @@ public class Couchbase {
         return value;
     }
 
-    static public Boolean optBoolean(Map<String, Object> map, String key) {
+    static public Boolean optBoolean(Map<String, Object> map, String key, Boolean fallback) {
         Boolean value = null;
 
         Object obj = opt(map, key);
         if( null != obj && obj instanceof Boolean ){
             value = (Boolean) obj;
+        }
+
+        if (value == null) {
+            return fallback;
         }
 
         return value;

--- a/app/src/main/res/layout/dialog_sync_result.xml
+++ b/app/src/main/res/layout/dialog_sync_result.xml
@@ -25,4 +25,26 @@
         android:layout_marginStart="20dp"
         android:layout_marginEnd="20dp" />
 
+    <android.support.v4.widget.Space
+        android:layout_width="match_parent"
+        android:layout_height="20dp" />
+
+    <TextView
+        android:id="@+id/sync_total_documents_deleted_result"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp" />
+
+    <android.support.v4.widget.Space
+        android:layout_width="match_parent"
+        android:layout_height="20dp" />
+
+    <TextView
+        android:id="@+id/sync_requested_documents_deleted_result"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="sync_result_positive">RELOAD ATLAS</string>
     <string name="sync_client_update">Local Documents Updated: %d / %d</string>
     <string name="sync_remote_update">Remote Documents Updated: %d / %d</string>
+    <string name="sync_local_delete">Documents Deleted: %d</string>
+    <string name="sync_remote_delete">Document Delete Requests: %d</string>
 
     <string name="delete_atlas_title">Remove Account</string>
     <string name="delete_atlas_message">Are you sure you want to remove the account from your device?</string>


### PR DESCRIPTION
Completes Issue #54

1. Sending delete requests to the server
2. Deleting documents from the local upon sync, not on delete button.
3. Keeping track of deleted documents from the Document Status Servlet.
4. Displaying deletion statuses as part of the popup displayed at the end of sync.

